### PR TITLE
Simplify test runs

### DIFF
--- a/pages/page.rb
+++ b/pages/page.rb
@@ -238,6 +238,9 @@ module Page
   # @param [String] desired_option
   # @param [String] create_type
   def enter_auto_complete(input_locator, options_locator, desired_option, create_type=nil)
+    # Force the current browser window into focus
+    @driver.switch_to.window @driver.window_handle
+
     # User enters a value in the input
     if desired_option && !desired_option.empty?
       wait_for_element_and_type(input_locator, desired_option)

--- a/spec/ucb/tools/batch_page_spec.rb
+++ b/spec/ucb/tools/batch_page_spec.rb
@@ -5,7 +5,7 @@ describe 'Batch' do
   include Logging
   include WebDriverManager
 
-  test_run = TestConfig.new
+  test_run = TestConfig.new Deployment::CORE
   test_id = Time.now.to_i
 
   before(:all) do

--- a/spec/ucb/tools/reports_page_spec.rb
+++ b/spec/ucb/tools/reports_page_spec.rb
@@ -5,7 +5,7 @@ describe 'Reports' do
   include Logging
   include WebDriverManager
 
-  test_run = TestConfig.new
+  test_run = TestConfig.new Deployment::CORE
   test_id = Time.now.to_i
 
   before(:all) do


### PR DESCRIPTION
- When the browser is not headless and it does not have focus on the machine, the auto-complete fields don't fire. Before trying to interact with an auto-complete, the tests will force the browser window into focus.
- Explicitly defines the deployment under test in each spec rather than relying on the settings yaml.