### PR TITLE
CC-1301: Object Current Location Test

### DIFF
--- a/pages/collection_space_pages.rb
+++ b/pages/collection_space_pages.rb
@@ -30,6 +30,8 @@ module CollectionSpacePages
   def create_new_button; {:name => 'create'} end
   def run_button; {:name => 'run'} end
   def clone_button; {:name => 'clone'} end
+  def unrelate_button; {:name => 'unrelate'} end
+  def unrelate_option; {:xpath => '//button[@name = "cancel"]/following-sibling::button'} end
   def header_bar; {:xpath => '//header/div'} end
   def page_h1; {:xpath => '//h1'} end
   def page_h2; {:xpath => '//h2'} end
@@ -342,6 +344,16 @@ module CollectionSpacePages
     wait_for_element_and_click clone_button
   end
 
+  def click_unrelate_button
+    logger.info 'Clicking the Unrelate button'
+    wait_for_element_and_click unrelate_button
+  end
+
+  def unrelate_record
+    logger.info 'Removing a related record'
+    click_unrelate_button
+    wait_for_element_and_click unrelate_option
+  end
   # LOG OUT
 
   # Logs out using the sign out link in the header

--- a/spec/navigate_primary_secondary_tabs.rb
+++ b/spec/navigate_primary_secondary_tabs.rb
@@ -32,11 +32,11 @@ if test_run.deployment == Deployment::CORE
       @create_new_page.click_create_new_acquisition
       @acquisition_page.create_new_acquisition @test_proc
       @core_id = "#{@test_proc[CoreAcquisitionData::ACQUIS_REF_NUM.name]}"
-
     end
 
     after(:all) { quit_browser test_run.driver }
 
+    current_date = (Date.today - 1).to_s
     primary_tab = {:xpath => '//button[contains(., "Primary Record")]'}
     all_secondary_tabs = ["Objects", "Acquisitions", "Condition Checks", "Conservation Treatments",
                           "Exhibitions" , "Groups", "Intakes", "Loans In", "Loans Out", "Location/Movement/Inventory",
@@ -46,7 +46,7 @@ if test_run.deployment == Deployment::CORE
       @search_page.quick_search("Acquisitions", [], @core_id)
       @search_results_page.click_result(0)
 
-      i = 5
+      i = 30
       [["close", "Location/Movement/Inventory"], ["cancel", "Exhibitions"]].each do |(button, tab)|
         @acquisition_page.wait_for_element_and_type(@acquisition_page.structured_date_input_locator([]),  (Date.today - i).to_s)
         @acquisition_page.hit_enter
@@ -66,21 +66,24 @@ if test_run.deployment == Deployment::CORE
       expect(@acquisition_page.enabled? movement_tab).to be false
 
       @acquisition_page.wait_for_element_and_click(primary_tab)
-      expect(CoreAcquisitionData::ACCESSION_DATE_GRP.name).eql?((Date.today - 1).to_s)
+      ad_text = test_run.driver.find_element(:xpath => '//label[contains(., "Accession date")]/following-sibling::div//input').attribute('value')
+      expect(ad_text == current_date)
       @acquisition_page.wait_for_element_and_click(:xpath => '//button[@aria-label = "close"]')
-
-      @acquisition_page.wait_for_element_and_type(@acquisition_page.structured_date_input_locator([]),  (Date.today - 4).to_s)
+      @acquisition_page.wait_for_element_and_type(@acquisition_page.structured_date_input_locator([]),  (Date.today - i).to_s)
       @acquisition_page.hit_enter
 
       exhibition_tab = {:xpath => '//button[@data-recordtype = "exhibition"]'}
       @acquisition_page.wait_for_element_and_click(exhibition_tab)
       dialog_popup = @acquisition_page.element_text(:xpath => '//div[@role = "dialog"]//div')
       expect(dialog_popup.include? "about to leave a record that has unsaved changes").to be true
+
       @acquisition_page.save_and_continue
       expect(@acquisition_page.enabled? exhibition_tab).to be false
 
       @acquisition_page.wait_for_element_and_click(primary_tab)
-      expect(CoreAcquisitionData::ACCESSION_DATE_GRP.name).eql?((Date.today - 4).to_s)
+      ad_text = test_run.driver.find_element(:xpath => '//label[contains(., "Accession date")]/following-sibling::div//input').attribute('value')
+      expect(ad_text == ((Date.today - i).to_s))
+      current_date = (Date.today - i).to_s
       @acquisition_page.wait_for_element_and_click(:xpath => '//button[@aria-label = "close"]')
     end
 
@@ -88,8 +91,8 @@ if test_run.deployment == Deployment::CORE
       @acquisition_page.quick_search("Acquisitions", [], @core_id)
       @search_results_page.click_result(0)
 
+      i = 8
       all_secondary_tabs.each do |tab|
-        i = 3
         ["close", "cancel"].each do |button|
           @acquisition_page.wait_for_element_and_type(@acquisition_page.structured_date_input_locator([]),  (Date.today - i).to_s)
           @acquisition_page.hit_enter
@@ -100,33 +103,38 @@ if test_run.deployment == Deployment::CORE
 
           @acquisition_page.wait_for_element_and_click(:xpath => "//div[@role = \"presentation\"]//button[@name = \"#{button}\"]")
           expect(@acquisition_page.exists? dialog_popup).to be false
-
-          if i == 3
+          if button == "close"
             @acquisition_page.wait_for_element_and_click(:xpath => '//button[@aria-label = "close"]')
           end
           i += 1
         end
+
         secondary_tab = {:xpath => "//button[contains(., \"#{tab}\")]"}
         @acquisition_page.wait_for_element_and_click(secondary_tab)
         @acquisition_page.revert_and_continue
         expect(@acquisition_page.enabled? secondary_tab).to be false
 
         @acquisition_page.wait_for_element_and_click(primary_tab)
-        expect(CoreAcquisitionData::ACCESSION_DATE_GRP.name).eql?((Date.today - 1).to_s)
-
-        @acquisition_page.wait_for_element_and_type(@acquisition_page.structured_date_input_locator([]),  (Date.today - 8).to_s)
+        ad_text = test_run.driver.find_element(:xpath => '//label[contains(., "Accession date")]/following-sibling::div//input').attribute('value')
+        expect(ad_text == current_date).to be true
+        @acquisition_page.wait_for_element_and_type(@acquisition_page.structured_date_input_locator([]),  (Date.today - i).to_s)
         @acquisition_page.hit_enter
+
         @acquisition_page.wait_for_element_and_click(secondary_tab)
         dialog_popup = @acquisition_page.element_text(:xpath => '//div[@role = "dialog"]//div')
         expect(dialog_popup.include? "about to leave a record that has unsaved changes").to be true
-        @acquisition_page.save_and_continue
 
+        @acquisition_page.save_and_continue
         expect(@acquisition_page.enabled? secondary_tab).to be false
+        current_date = (Date.today - i).to_s
+
         @acquisition_page.wait_for_element_and_click(primary_tab)
-        expect(CoreAcquisitionData::ACCESSION_DATE_GRP.name).eql?((Date.today - 8).to_s)
+        ad_text = test_run.driver.find_element(:xpath => '//label[contains(., "Accession date")]/following-sibling::div//input').attribute('value')
+        expect(ad_text == current_date)
         @acquisition_page.wait_for_element_and_click(:xpath => '//button[@aria-label = "close"]')
+        i += 1
       end
     end
-
   end
+
 end

--- a/spec/navigate_primary_secondary_tabs.rb
+++ b/spec/navigate_primary_secondary_tabs.rb
@@ -1,0 +1,132 @@
+require_relative '../spec_helper'
+
+test_run = TestConfig.new
+
+if test_run.deployment == Deployment::CORE
+
+  describe 'CollectionSpace' do
+
+    include Logging
+    include WebDriverManager
+
+    before(:all) do
+      test_run.set_driver launch_browser
+      @admin = test_run.get_admin_user
+      @login_page = test_run.get_page CoreLoginPage
+      @create_new_page = test_run.get_page CoreCreateNewPage
+      @search_page = test_run.get_page CoreSearchPage
+      @search_results_page = test_run.get_page CoreSearchResultsPage
+      @object_page = test_run.get_page CoreObjectPage
+      @acquisition_page = test_run.get_page CoreAcquisitionPage
+
+      @login_page.load_page
+      @login_page.log_in("students@cspace.berkeley.edu", "cspacestudents")
+      #@admin.username, @admin.password)
+
+      @test_proc = {
+        CoreAcquisitionData::ACQUIS_METHOD.name => 'gift',
+        CoreAcquisitionData::ACCESSION_DATE_GRP.name => (Date.today - 1).to_s
+      }
+      test_run.set_unique_test_id(@test_proc, CoreAcquisitionData::ACQUIS_REF_NUM.name)
+      @search_page.click_create_new_link
+      @create_new_page.click_create_new_acquisition
+      @acquisition_page.create_new_acquisition @test_proc
+      @core_id = "#{@test_proc[CoreAcquisitionData::ACQUIS_REF_NUM.name]}"
+
+    end
+
+    after(:all) { quit_browser test_run.driver }
+
+    primary_tab = {:xpath => '//button[contains(., "Primary Record")]'}
+    all_secondary_tabs = ["Objects", "Acquisitions", "Condition Checks", "Conservation Treatments",
+                          "Exhibitions" , "Groups", "Intakes", "Loans In", "Loans Out", "Location/Movement/Inventory",
+                          "Media Handling", "Object Exits", "Use of Collections", "Valuation Controls"]
+
+    it "Navigates Between Secondary and Primary Tabs" do
+      @search_page.quick_search("Acquisitions", [], @core_id)
+      @search_results_page.click_result(0)
+
+      i = 5
+      [["close", "Location/Movement/Inventory"], ["cancel", "Exhibitions"]].each do |(button, tab)|
+        @acquisition_page.wait_for_element_and_type(@acquisition_page.structured_date_input_locator([]),  (Date.today - i).to_s)
+        @acquisition_page.hit_enter
+        @acquisition_page.select_related_type tab
+
+        dialog_popup = @acquisition_page.element_text(:xpath => '//div[@role = "dialog"]//div')
+        expect(dialog_popup.include? "about to leave a record that has unsaved changes").to be true
+
+        @acquisition_page.wait_for_element_and_click(:xpath => "//div[@role = \"presentation\"]//button[@name = \"#{button}\"]")
+        expect(@acquisition_page.exists? dialog_popup).to be false
+        i += 1
+      end
+
+      movement_tab = {:xpath => '//button[@data-recordtype = "movement"][1]'}
+      @acquisition_page.wait_for_element_and_click(movement_tab)
+      @acquisition_page.revert_and_continue
+      expect(@acquisition_page.enabled? movement_tab).to be false
+
+      @acquisition_page.wait_for_element_and_click(primary_tab)
+      expect(CoreAcquisitionData::ACCESSION_DATE_GRP.name).eql?((Date.today - 1).to_s)
+      @acquisition_page.wait_for_element_and_click(:xpath => '//button[@aria-label = "close"]')
+
+      @acquisition_page.wait_for_element_and_type(@acquisition_page.structured_date_input_locator([]),  (Date.today - 4).to_s)
+      @acquisition_page.hit_enter
+
+      exhibition_tab = {:xpath => '//button[@data-recordtype = "exhibition"]'}
+      @acquisition_page.wait_for_element_and_click(exhibition_tab)
+      dialog_popup = @acquisition_page.element_text(:xpath => '//div[@role = "dialog"]//div')
+      expect(dialog_popup.include? "about to leave a record that has unsaved changes").to be true
+      @acquisition_page.save_and_continue
+      expect(@acquisition_page.enabled? exhibition_tab).to be false
+
+      @acquisition_page.wait_for_element_and_click(primary_tab)
+      expect(CoreAcquisitionData::ACCESSION_DATE_GRP.name).eql?((Date.today - 4).to_s)
+      @acquisition_page.wait_for_element_and_click(:xpath => '//button[@aria-label = "close"]')
+    end
+
+    it "Navigates Between ALL Secondary and Primary Tabs" do
+      @acquisition_page.quick_search("Acquisitions", [], @core_id)
+      @search_results_page.click_result(0)
+
+      all_secondary_tabs.each do |tab|
+        i = 3
+        ["close", "cancel"].each do |button|
+          @acquisition_page.wait_for_element_and_type(@acquisition_page.structured_date_input_locator([]),  (Date.today - i).to_s)
+          @acquisition_page.hit_enter
+          @acquisition_page.select_related_type tab
+
+          dialog_popup = @acquisition_page.element_text(:xpath => '//div[@role = "dialog"]//div')
+          expect(dialog_popup.include? "about to leave a record that has unsaved changes").to be true
+
+          @acquisition_page.wait_for_element_and_click(:xpath => "//div[@role = \"presentation\"]//button[@name = \"#{button}\"]")
+          expect(@acquisition_page.exists? dialog_popup).to be false
+
+          if i == 3
+            @acquisition_page.wait_for_element_and_click(:xpath => '//button[@aria-label = "close"]')
+          end
+          i += 1
+        end
+        secondary_tab = {:xpath => "//button[contains(., \"#{tab}\")]"}
+        @acquisition_page.wait_for_element_and_click(secondary_tab)
+        @acquisition_page.revert_and_continue
+        expect(@acquisition_page.enabled? secondary_tab).to be false
+
+        @acquisition_page.wait_for_element_and_click(primary_tab)
+        expect(CoreAcquisitionData::ACCESSION_DATE_GRP.name).eql?((Date.today - 1).to_s)
+
+        @acquisition_page.wait_for_element_and_type(@acquisition_page.structured_date_input_locator([]),  (Date.today - 8).to_s)
+        @acquisition_page.hit_enter
+        @acquisition_page.wait_for_element_and_click(secondary_tab)
+        dialog_popup = @acquisition_page.element_text(:xpath => '//div[@role = "dialog"]//div')
+        expect(dialog_popup.include? "about to leave a record that has unsaved changes").to be true
+        @acquisition_page.save_and_continue
+
+        expect(@acquisition_page.enabled? secondary_tab).to be false
+        @acquisition_page.wait_for_element_and_click(primary_tab)
+        expect(CoreAcquisitionData::ACCESSION_DATE_GRP.name).eql?((Date.today - 8).to_s)
+        @acquisition_page.wait_for_element_and_click(:xpath => '//button[@aria-label = "close"]')
+      end
+    end
+
+  end
+end

--- a/spec/navigate_primary_secondary_tabs.rb
+++ b/spec/navigate_primary_secondary_tabs.rb
@@ -20,8 +20,7 @@ if test_run.deployment == Deployment::CORE
       @acquisition_page = test_run.get_page CoreAcquisitionPage
 
       @login_page.load_page
-      @login_page.log_in("students@cspace.berkeley.edu", "cspacestudents")
-      #@admin.username, @admin.password)
+      @login_page.log_in(@admin.username, @admin.password)
 
       @test_proc = {
         CoreAcquisitionData::ACQUIS_METHOD.name => 'gift',
@@ -71,6 +70,7 @@ if test_run.deployment == Deployment::CORE
       @acquisition_page.wait_for_element_and_click(:xpath => '//button[@aria-label = "close"]')
       @acquisition_page.wait_for_element_and_type(@acquisition_page.structured_date_input_locator([]),  (Date.today - i).to_s)
       @acquisition_page.hit_enter
+      current_date = (Date.today - i).to_s
 
       exhibition_tab = {:xpath => '//button[@data-recordtype = "exhibition"]'}
       @acquisition_page.wait_for_element_and_click(exhibition_tab)
@@ -82,8 +82,8 @@ if test_run.deployment == Deployment::CORE
 
       @acquisition_page.wait_for_element_and_click(primary_tab)
       ad_text = test_run.driver.find_element(:xpath => '//label[contains(., "Accession date")]/following-sibling::div//input').attribute('value')
-      expect(ad_text == ((Date.today - i).to_s))
-      current_date = (Date.today - i).to_s
+      expect(ad_text == current_date)
+
       @acquisition_page.wait_for_element_and_click(:xpath => '//button[@aria-label = "close"]')
     end
 
@@ -119,6 +119,7 @@ if test_run.deployment == Deployment::CORE
         expect(ad_text == current_date).to be true
         @acquisition_page.wait_for_element_and_type(@acquisition_page.structured_date_input_locator([]),  (Date.today - i).to_s)
         @acquisition_page.hit_enter
+        current_date = (Date.today - i).to_s
 
         @acquisition_page.wait_for_element_and_click(secondary_tab)
         dialog_popup = @acquisition_page.element_text(:xpath => '//div[@role = "dialog"]//div')
@@ -126,7 +127,6 @@ if test_run.deployment == Deployment::CORE
 
         @acquisition_page.save_and_continue
         expect(@acquisition_page.enabled? secondary_tab).to be false
-        current_date = (Date.today - i).to_s
 
         @acquisition_page.wait_for_element_and_click(primary_tab)
         ad_text = test_run.driver.find_element(:xpath => '//label[contains(., "Accession date")]/following-sibling::div//input').attribute('value')

--- a/spec/object_current_location_test.rb
+++ b/spec/object_current_location_test.rb
@@ -1,0 +1,218 @@
+require_relative '../spec_helper'
+
+test_run = TestConfig.new
+
+if test_run.deployment == Deployment::CORE
+
+  describe 'CollectionSpace' do
+
+    include Logging
+    include WebDriverManager
+
+    before(:all) do
+      test_run.set_driver launch_browser
+      @admin = test_run.get_admin_user
+      @login_page = test_run.get_page CoreLoginPage
+      @create_new_page = test_run.get_page CoreCreateNewPage
+      @search_page = test_run.get_page CoreSearchPage
+      @search_results_page = test_run.get_page CoreSearchResultsPage
+      @object_page = test_run.get_page CoreObjectPage
+      @inventory_movement_page = test_run.get_page CoreInventoryMovementPage
+      @login_page.load_page
+      @login_page.log_in('students@cspace.berkeley.edu', 'cspacestudents')
+    end
+
+    after(:all) { quit_browser test_run.driver }
+
+    proc_alpha = {:xpath => '//div[@aria-colindex = "2"][@title = "Alpha Location"]'}
+    proc_bravo = {:xpath => '//div[@aria-colindex = "2"][@title = "Bravo Location"]'}
+    proc_charlie = {:xpath => '//div[@aria-colindex = "2"][@title = "Charlie Organization"]'}
+    terms_alpha = {:xpath => '//div[@aria-colindex = "1"][@title ="Alpha Location"]'}
+    terms_bravo = {:xpath => '//div[@aria-colindex = "1"][@title ="Bravo Location"]'}
+    terms_charlie = {:xpath => '//div[@aria-colindex = "1"][@title = "Charlie Organization"]'}
+
+    it "Object Current Location is Created/Updated - Test 1a" do
+      @search_page.click_create_new_link
+      @create_new_page.click_create_new_object
+      tango_object = {
+        CoreObjectData::TITLE_GRP.name => [
+          {
+            CoreObjectData::TITLE.name => "Tango Object"
+          }
+        ]
+      }
+      test_run.set_unique_test_id(tango_object, CoreObjectData::OBJECT_NUM.name)
+      @object_page.create_new_object tango_object
+      @object_page.scroll_to_top
+      @object_page.select_related_type "Location/Movement/Inventory"
+      @object_page.click_create_new_button
+
+      alpha_location_lmi = {
+        CoreInventoryMovementData::CURRENT_LOCATION.name => "Alpha Location",
+        CoreInventoryMovementData::LOCATION_DATE.name => "1700-01-01"
+      }
+      test_run.set_unique_test_id(alpha_location_lmi, CoreInventoryMovementData::REF_NUM.name)
+      @inventory_movement_page.enter_reference_number alpha_location_lmi
+      @inventory_movement_page.hit_tab
+      current_location_input = @inventory_movement_page.input_locator([], CoreInventoryMovementData::CURRENT_LOCATION.name)
+      current_location_options = @inventory_movement_page.input_options_locator([], CoreInventoryMovementData::CURRENT_LOCATION.name)
+      @inventory_movement_page.scroll_to_element(current_location_input)
+      @inventory_movement_page.enter_auto_complete(current_location_input, current_location_options, "Alpha Location", 'Offsite Storage Locations')
+      @inventory_movement_page.enter_location_date alpha_location_lmi
+      @inventory_movement_page.save_record_only
+
+      @inventory_movement_page.quick_search("Objects", [], "Tango Object")
+      @search_results_page.click_result(0)
+
+      test_run.driver.navigate.refresh
+      @object_page.expand_sidebar_related_proc
+      expect(@object_page.exists? proc_alpha).to be true
+      expect(CoreObjectData::COMPUTED_LOCATION.name).eql? "Alpha Location"
+      @object_page.expand_sidebar_terms_used
+      sleep Config.click_wait
+      expect(@object_page.exists? terms_alpha).to be true
+    end
+
+    it "Object Current Location is Created/Updated - Test 1b" do
+      @search_page.click_create_new_link
+      @create_new_page.click_create_new_movement
+      bravo_location = {
+        CoreInventoryMovementData::CURRENT_LOCATION.name => "Bravo Location",
+        CoreInventoryMovementData::LOCATION_DATE.name => "1800-01-01"
+      }
+      test_run.set_unique_test_id(bravo_location, CoreInventoryMovementData::REF_NUM.name)
+      @inventory_movement_page.enter_reference_number bravo_location
+      @inventory_movement_page.hit_tab
+      current_location_input = @inventory_movement_page.input_locator([], CoreInventoryMovementData::CURRENT_LOCATION.name)
+      current_location_options = @inventory_movement_page.input_options_locator([], CoreInventoryMovementData::CURRENT_LOCATION.name)
+      @inventory_movement_page.scroll_to_element(current_location_input)
+      @inventory_movement_page.enter_auto_complete(current_location_input, current_location_options, "Bravo Location", 'Offsite Storage Locations')
+      @inventory_movement_page.enter_location_date bravo_location
+      @inventory_movement_page.save_record_only
+
+      @inventory_movement_page.quick_search("Objects", [], "Tango Object")
+      @search_results_page.click_result(0)
+
+      @object_page.click_add_related_procedure
+      dropdown_input = {:xpath => '//div[contains(@class,"SearchFormRecordType")]//input'}
+      dropdown_options = {:xpath => '//div[@class = "cspace-layout-Popup--common"]//li' }
+      @object_page.wait_for_options_and_select(dropdown_input, dropdown_options, "Location/Movement/Inventory")
+      keywords_input_locator = {:xpath => '//label[text()="Keywords"]/following-sibling::input'}
+      @object_page.wait_for_element_and_type(keywords_input_locator, "Bravo")
+      test_run.driver.find_element(:xpath => '//footer//button[@name = "search"]').click
+      @object_page.wait_for_element_and_click(:xpath => "//div[@class=\"cspace-ui-SearchResultTable--common\"]//div[@aria-label=\"row\"][contains(.,'Bravo')]//input")
+      test_run.driver.find_element(:name => "accept").click
+
+      @object_page.expand_sidebar_related_proc
+      expect(@object_page.exists?(proc_bravo) && @object_page.exists?(proc_alpha)).to be true
+      expect(CoreObjectData::COMPUTED_LOCATION.name).eql? "Alpha Location"
+      @object_page.expand_sidebar_terms_used
+      sleep Config.click_wait
+      expect(@object_page.exists? terms_alpha).to be true
+
+      test_run.driver.navigate.refresh
+
+      expect(CoreObjectData::COMPUTED_LOCATION.name).eql? "Bravo Location"
+      @object_page.expand_sidebar_terms_used
+      sleep Config.click_wait
+      expect(@object_page.exists? terms_bravo).to be true
+    end
+
+    it "Object Current Location is Created/Updated - Test 1c" do
+      @object_page.click_create_new_link
+      @create_new_page.click_create_new_movement
+      charlie_org = {
+        CoreInventoryMovementData::CURRENT_LOCATION.name => "Charlie Organization",
+        CoreInventoryMovementData::LOCATION_DATE.name => "1900-01-01"
+      }
+      test_run.set_unique_test_id(charlie_org, CoreInventoryMovementData::REF_NUM.name)
+      @inventory_movement_page.enter_reference_number charlie_org
+      @inventory_movement_page.hit_tab
+      current_location_input = @inventory_movement_page.input_locator([], CoreInventoryMovementData::CURRENT_LOCATION.name)
+      current_location_options = @inventory_movement_page.input_options_locator([], CoreInventoryMovementData::CURRENT_LOCATION.name)
+      @inventory_movement_page.scroll_to_element(current_location_input)
+      @inventory_movement_page.enter_auto_complete(current_location_input, current_location_options, "Charlie Organization", 'Local Organizations')
+      @inventory_movement_page.enter_location_date charlie_org
+      @inventory_movement_page.save_record_only
+
+      @inventory_movement_page.quick_search("Objects", [], "Tango Object")
+      @search_results_page.click_result(0)
+
+      test_run.driver.find_element(:xpath => '//button[@data-recordtype ="movement"]').click
+      @object_page.wait_for_element_and_click(:name => 'relate')
+      keywords_input_locator = {:xpath => '//label[text()="Keywords"]/following-sibling::input'}
+      @object_page.wait_for_element_and_type(keywords_input_locator, "Charlie")
+      test_run.driver.find_element(:xpath => '//footer//button[@name = "search"]').click
+      @object_page.wait_for_element_and_click(:xpath => "//div[@class=\"cspace-ui-SearchResultTable--common\"]//div[@aria-label=\"row\"][contains(.,'Charlie Organization')]//input")
+      test_run.driver.find_element(:name => "accept").click
+      test_run.driver.find_element(:xpath => '//button[contains(.,"Primary Record")]').click
+
+      @object_page.expand_sidebar_related_proc
+      expect(@object_page.exists?(proc_charlie) && @object_page.exists?(proc_bravo) && @object_page.exists?(proc_alpha)).to be true
+      expect(CoreObjectData::COMPUTED_LOCATION.name).eql? "Bravo Location"
+      @object_page.expand_sidebar_terms_used
+      sleep Config.click_wait
+      expect(@object_page.exists? terms_bravo).to be true
+
+      test_run.driver.navigate.refresh
+
+      expect(CoreObjectData::COMPUTED_LOCATION.name).eql? "Charlie Organization"
+      @object_page.expand_sidebar_terms_used
+      sleep Config.click_wait
+      expect(@object_page.exists? terms_charlie).to be true
+    end
+
+    it "Object Current Location is Created/Updated - Test 2" do
+      @object_page.quick_search("Location/Movement/Inventory", [], "Alpha Location")
+      @search_results_page.click_result(0)
+      location_date = @inventory_movement_page.input_locator([], 'locationDate')
+      @inventory_movement_page.wait_for_element_and_type(location_date, "2000-01-01")
+      @inventory_movement_page.hit_enter
+      @inventory_movement_page.save_record_only
+      @inventory_movement_page.expand_sidebar_related_obj
+      test_run.driver.find_element(:xpath => '//*[@aria-colindex = "2"][@title = "Tango Object"]').click
+
+      expect(CoreObjectData::COMPUTED_LOCATION.name).eql? "Alpha Location"
+      @object_page.expand_sidebar_terms_used
+      test_run.driver.navigate.refresh
+      sleep Config.click_wait
+      expect(@object_page.exists? terms_alpha).to be true
+    end
+
+    it "Object Current Location is Updated When a Related L/M/I is Deleted - Test 3" do
+      @object_page.expand_sidebar_related_proc
+      test_run.driver.find_element(:xpath => '//*[@aria-colindex = "2"][@title = "Alpha Location"]').click
+      @inventory_movement_page.delete_record
+      @inventory_movement_page.quick_search("Objects", [], "Tango Object")
+      @search_results_page.click_result(0)
+
+      test_run.driver.navigate.refresh
+      @object_page.expand_sidebar_related_proc
+      num_of_proc = {:xpath => '//span[contains(., "Related Procedures: 2")]'}
+      expect(@object_page.exists? num_of_proc).to be true
+      expect(@object_page.exists?(proc_charlie) && @object_page.exists?(proc_bravo)).to be true
+      expect(CoreObjectData::COMPUTED_LOCATION.name).eql? "Charlie Organization"
+      @object_page.expand_sidebar_terms_used
+      sleep Config.click_wait
+      expect(@object_page.exists? terms_charlie).to be true
+    end
+
+    it "Object Current Location is Updated When Relationship to L/M/I is Deleted - Test 4" do
+      test_run.driver.find_element(:xpath => '//button[contains(.,"Location/Movement/Inventory")]').click
+      @object_page.wait_for_element_and_click(:xpath => '//div[@title = "Charlie Organization"][@aria-colindex = 4]/preceding::input[1]')
+      @object_page.unrelate_record
+      @object_page.quick_search("Objects", [], "Tango Object")
+      @search_results_page.click_result(0)
+
+      test_run.driver.navigate.refresh
+      @object_page.expand_sidebar_related_proc
+      num_of_proc = {:xpath => '//span[contains(., "Related Procedures: 1")]'}
+      expect(@object_page.exists? num_of_proc).to be true
+      expect(@object_page.exists? proc_bravo).to be true
+      expect(CoreObjectData::COMPUTED_LOCATION.name).eql? "Bravo Location"
+      @object_page.expand_sidebar_terms_used
+      sleep Config.click_wait
+      expect(@object_page.exists? terms_bravo).to be true
+    end
+  end
+end

--- a/spec/object_current_location_test.rb
+++ b/spec/object_current_location_test.rb
@@ -19,7 +19,7 @@ if test_run.deployment == Deployment::CORE
       @object_page = test_run.get_page CoreObjectPage
       @inventory_movement_page = test_run.get_page CoreInventoryMovementPage
       @login_page.load_page
-      @login_page.log_in('students@cspace.berkeley.edu', 'cspacestudents')
+      @login_page.log_in(@admin.username, @admin.password)
     end
 
     after(:all) { quit_browser test_run.driver }

--- a/spec/ucb/misc/numeric_fields.rb
+++ b/spec/ucb/misc/numeric_fields.rb
@@ -26,7 +26,7 @@ if test_run.deployment == Deployment::CORE
 
       #set up a record for each record type to ensure presence of existing file
       @login_page.load_page
-      @login_page.log_in('students@cspace.berkeley.edu', 'cspacestudents')
+      @login_page.log_in(@admin.username, @admin.password)
 
       #all records will have ref/id num = @test_rec_num
       @test_rec_num = "0000000"


### PR DESCRIPTION
(two tests total) 
- Added test for Object Current Location in spec/object_current_location_test.rb
- Added test for Navigate Between Primary and Secondary Tabs in spec/navigate_primary_secondary_tabs.rb
- Added variables and methods for the unrelate button in collection_space_pages.rb

Object Current Location [[Test Plan](https://collectionspace.atlassian.net/wiki/spaces/COL/pages/345866302/Object+Current+Location+-+QA+Test+Plan)] [[JIRA]( https://jira.ets.berkeley.edu/jira/browse/CC-1301)] 
Navigate Between Primary and Secondary Tabs [[Test Plan](https://collectionspace.atlassian.net/wiki/spaces/COL/pages/339902624/Navigating+Between+Primary+and+Secondary+Tabs+-+QA+Test+Plan)] [[JIRA](https://jira.ets.berkeley.edu/jira/browse/CC-1324)] 