### PR TITLE
CC-1341: "Right Side Bar - Search Related Records" Test

### DIFF
--- a/pages/collection_space_pages.rb
+++ b/pages/collection_space_pages.rb
@@ -344,11 +344,13 @@ module CollectionSpacePages
     wait_for_element_and_click clone_button
   end
 
+  # Clicks the unrelate button for a record
   def click_unrelate_button
     logger.info 'Clicking the Unrelate button'
     wait_for_element_and_click unrelate_button
   end
 
+  # Removes a related record
   def unrelate_record
     logger.info 'Removing a related record'
     click_unrelate_button

--- a/pages/core/core_sidebar.rb
+++ b/pages/core/core_sidebar.rb
@@ -7,6 +7,7 @@ module CoreSidebar
 
   def section_xpath(label); "//section[contains(.,'#{label}:')]" end
   def button_locator(label); {:xpath => "//button[contains(.,'#{label}:')]"} end
+  def open_related_button_locator(path); {:xpath => "//a[contains(@href,'/list/#{path}')]"} end
   def add_related_button_locator(path); {:xpath => "//a[contains(@href,'/list/#{path}')]/following-sibling::button"} end
   def expanded_div_locator(label); {:xpath => "#{section_xpath(label)}/div"} end
   def links_locator(label); {:xpath => "#{section_xpath(label)}//a[@role='row']"} end
@@ -94,6 +95,11 @@ module CoreSidebar
     wait_for_element_and_click related_obj_link(obj)
   end
 
+  # Clicks the 'Open' button to view related objects
+  def click_open_related_object
+    wait_for_element_and_click open_related_button_locator('collectionobject')
+  end
+
   # Clicks the 'Add' button the relate an existing object
   def click_add_related_object
     wait_for_element_and_click related_obj_add_button
@@ -124,6 +130,11 @@ module CoreSidebar
     expand_sidebar_related_proc
     wait_for_options_and_select(related_proc_num_per_page_input, related_proc_num_per_page_option, '20')
   end
+
+  # Clicks the 'Open' button to view related procedures
+  def click_open_related_procedures
+    wait_for_element_and_click open_related_button_locator("procedure")
+  end 
 
   # Clicks the Add button to relate two procedures
   def click_add_related_procedure

--- a/spec/right_side_bar_search.rb
+++ b/spec/right_side_bar_search.rb
@@ -20,80 +20,66 @@ if test_run.deployment == Deployment::CORE
       @media_handling_page = test_run.get_page CoreMediaHandlingPage
 
       @login_page.load_page
-      @login_page.log_in("students@cspace.berkeley.edu", "cspacestudents")
-      #@admin.username, @admin.password)
+      @login_page.log_in(@admin.username, @admin.password)
     end
 
     after(:all) { quit_browser test_run.driver }
 
-    related_obj_open_button = {:xpath => '//button[@name = "add"]/preceding-sibling::a[contains(@href,"collectionobject")]'}
-    related_proc_open_button = {:xpath => '//button[@name = "add"]/preceding-sibling::a[contains(@href,"procedure")]'}
+    test_1_object = {  CoreObjectData::OBJECT_NUM.name => Time.now.to_i  }
+    title_bar_1_expected = {:xpath => "//header[contains(., \"Objects related to \"#{test_1_object[CoreObjectData::OBJECT_NUM.name]}\"\")]"}
+    test_2_acquisition = { CoreAcquisitionData::ACQUIS_REF_NUM.name => Time.now.to_i }
+    title_bar_2_expected = {:xpath => "//header[contains(., \"Procedures related to \"#{test_2_acquisition[CoreAcquisitionData::ACQUIS_REF_NUM.name]}\"\")]"}
+    related_rec_1, related_rec_2 = 3 * Time.now.to_i, 6 * Time.now.to_i
+
+    def rec_id_link(page); {:xpath => "//a[contains(., \"#{page}\")]"} end
+    def related_rec_row(reference_number); {:xpath => "//div[@role = \"gridcell\"][contains(text(), \"#{reference_number}\")]"} end
 
     it "search related object records" do
-      @search_page.click_create_new_link
-      @create_new_page.click_create_new_object
-      test_1_object = {  CoreObjectData::OBJECT_NUM.name => Time.now.to_i  }
-    #  test_1_ref_num = Time.now.to_i
-  #    @object_page.wait_for_element_and_type(@object_page.input_locator([],"objectNumber"), test_1_ref_num)
-  #    @object_page.click_save_button
-      @object_page.create_new_object test_1_object
-      @object_page.scroll_to_top
-      @object_page.wait_for_element_and_click(related_obj_open_button)
-      header_text = @object_page.element_text(:xpath => '//div[contains(@class, "SearchResultSummary")]//span')
-      expect(header_text == "No records found")
+       @search_page.click_create_new_link
+       @create_new_page.click_create_new_object
+       @object_page.create_new_object test_1_object
+       @object_page.scroll_to_top
+       @object_page.click_open_related_object
+       header_text = @object_page.element_text(:xpath => '//div[contains(@class, "SearchResultSummary")]//span')
+       expect(header_text == "No records found")
 
-      @object_page.wait_for_element_and_click(:xpath => "//a[contains(., \"#{test_1_object[CoreObjectData::OBJECT_NUM.name]}\")]")
-      @object_page.select_related_type("Objects")
-      related_obj_1, related_obj_2 = Time.now.to_i, 6 * Time.now.to_i
-      [related_obj_1, related_obj_2].each do |ref_num|
-        @object_page.click_create_new_button
-        @object_page.wait_for_element_and_type(@object_page.input_locator([],"objectNumber"), ref_num)
-        @object_page.save_record
-      end
-      @object_page.wait_for_element_and_click(related_obj_open_button)
-      test_run.driver.navigate.refresh
-      [related_obj_1, related_obj_2].each do |ref_num|
-        related_obj_row = {:xpath => "//div[@role = \"gridcell\"][contains(text(), \"#{ref_num}\")]"}
-        expect(@object_page.exists? related_obj_row)
-      end
-      title_bar_expected = {:xpath => "//header[contains(., \"Objects related to \"#{test_1_object[CoreObjectData::OBJECT_NUM.name]}\"\")]"}
-      expect(@object_page.exists? title_bar_expected)
-    end
+       @object_page.wait_for_element_and_click(rec_id_link(test_1_object[CoreObjectData::OBJECT_NUM.name]))
+       @object_page.select_related_type("Objects")
+       [related_rec_1, related_rec_2].each do |ref_num|
+         @object_page.click_create_new_button
+         @object_page.wait_for_element_and_type(@object_page.input_locator([],"objectNumber"), ref_num)
+         @object_page.save_record
+       end
+       @object_page.click_open_related_object
+       test_run.driver.navigate.refresh
+       [related_rec_1, related_rec_2].each do |ref_num|
+         expect(@object_page.exists? related_rec_row(ref_num))
+       end
+       expect(@object_page.exists? title_bar_1_expected)
+     end
 
     it "search related procedural records" do
       @search_page.click_create_new_link
       @create_new_page.click_create_new_acquisition
-      test_2_acquisition = { CoreAcquisitionData::ACQUIS_REF_NUM.name => Time.now.to_i }
-    #  test_2_ref_num = Time.now.to_i
-    #  @object_page.wait_for_element_and_type(@object_page.input_locator([],"acquisitionReferenceNumber"), test_1_ref_num)
       @acquisition_page.create_new_acquisition test_2_acquisition
       @acquisition_page.scroll_to_top
-      @acquisition_page.wait_for_element_and_click(related_proc_open_button)
+      @acquisition_page.click_open_related_procedures
       header_text = @object_page.element_text(:xpath => '//div[contains(@class, "SearchResultSummary")]//span')
       expect(header_text == "No records found")
 
-      @acquisition_page.wait_for_element_and_click(:xpath => "//a[contains(., \"#{test_2_acquisition[CoreAcquisitionData::ACQUIS_REF_NUM.name]}\")]")
+      @acquisition_page.wait_for_element_and_click(rec_id_link(test_2_acquisition[CoreAcquisitionData::ACQUIS_REF_NUM.name]))
       @acquisition_page.select_related_type("Media Handling")
-      related_proc_1, related_proc_2 = Time.now.to_i, 6 * Time.now.to_i
-      [related_proc_1, related_proc_2].each do |ref_num|
+      [related_rec_1, related_rec_2].each do |ref_num|
         @acquisition_page.click_create_new_button
         @acquisition_page.wait_for_element_and_type(@acquisition_page.input_locator([],"identificationNumber"), ref_num)
         @acquisition_page.save_record
       end
-      @acquisition_page.wait_for_element_and_click(related_proc_open_button)
+      @acquisition_page.click_open_related_procedures
       test_run.driver.navigate.refresh
-      [related_proc_1, related_proc_2].each do |ref_num|
-        related_proc_row = {:xpath => "//div[@role = \"gridcell\"][contains(text(), \"#{ref_num}\")]"}
-        expect(@acquisition_page.exists? related_proc_row)
+      [related_rec_1, related_rec_2].each do |ref_num|
+        expect(@acquisition_page.exists? related_rec_row(ref_num))
       end
-      title_bar_expected = {:xpath => "//header[contains(., \"Procedures related to \"#{test_2_acquisition[CoreAcquisitionData::ACQUIS_REF_NUM.name]}\"\")]"}
-      expect(@acquisition_page.exists? title_bar_expected)
-    end
-
-    it "test keyboard accessibility" do
-      ##TODO
-      #test that the search button (for Search Related Objects/Procedures) can be navigated to and activated by keyboard only
-      #expect: should be able to do all the above using keyboard only; tab-ordering and keys should be logical; should be able to see focus at all times  
+      expect(@acquisition_page.exists? title_bar_2_expected)
     end
 
   end

--- a/spec/right_side_bar_search.rb
+++ b/spec/right_side_bar_search.rb
@@ -1,0 +1,100 @@
+require_relative '../spec_helper'
+
+test_run = TestConfig.new
+
+if test_run.deployment == Deployment::CORE
+
+  describe 'CollectionSpace' do
+
+    include Logging
+    include WebDriverManager
+
+    before(:all) do
+      test_run.set_driver launch_browser
+      @admin = test_run.get_admin_user
+      @login_page = test_run.get_page CoreLoginPage
+      @create_new_page = test_run.get_page CoreCreateNewPage
+      @search_page = test_run.get_page CoreSearchPage
+      @object_page = test_run.get_page CoreObjectPage
+      @acquisition_page = test_run.get_page CoreAcquisitionPage
+      @media_handling_page = test_run.get_page CoreMediaHandlingPage
+
+      @login_page.load_page
+      @login_page.log_in("students@cspace.berkeley.edu", "cspacestudents")
+      #@admin.username, @admin.password)
+    end
+
+    after(:all) { quit_browser test_run.driver }
+
+    related_obj_open_button = {:xpath => '//button[@name = "add"]/preceding-sibling::a[contains(@href,"collectionobject")]'}
+    related_proc_open_button = {:xpath => '//button[@name = "add"]/preceding-sibling::a[contains(@href,"procedure")]'}
+
+    it "search related object records" do
+      @search_page.click_create_new_link
+      @create_new_page.click_create_new_object
+      test_1_object = {  CoreObjectData::OBJECT_NUM.name => Time.now.to_i  }
+    #  test_1_ref_num = Time.now.to_i
+  #    @object_page.wait_for_element_and_type(@object_page.input_locator([],"objectNumber"), test_1_ref_num)
+  #    @object_page.click_save_button
+      @object_page.create_new_object test_1_object
+      @object_page.scroll_to_top
+      @object_page.wait_for_element_and_click(related_obj_open_button)
+      header_text = @object_page.element_text(:xpath => '//div[contains(@class, "SearchResultSummary")]//span')
+      expect(header_text == "No records found")
+
+      @object_page.wait_for_element_and_click(:xpath => "//a[contains(., \"#{test_1_object[CoreObjectData::OBJECT_NUM.name]}\")]")
+      @object_page.select_related_type("Objects")
+      related_obj_1, related_obj_2 = Time.now.to_i, 6 * Time.now.to_i
+      [related_obj_1, related_obj_2].each do |ref_num|
+        @object_page.click_create_new_button
+        @object_page.wait_for_element_and_type(@object_page.input_locator([],"objectNumber"), ref_num)
+        @object_page.save_record
+      end
+      @object_page.wait_for_element_and_click(related_obj_open_button)
+      test_run.driver.navigate.refresh
+      [related_obj_1, related_obj_2].each do |ref_num|
+        related_obj_row = {:xpath => "//div[@role = \"gridcell\"][contains(text(), \"#{ref_num}\")]"}
+        expect(@object_page.exists? related_obj_row)
+      end
+      title_bar_expected = {:xpath => "//header[contains(., \"Objects related to \"#{test_1_object[CoreObjectData::OBJECT_NUM.name]}\"\")]"}
+      expect(@object_page.exists? title_bar_expected)
+    end
+
+    it "search related procedural records" do
+      @search_page.click_create_new_link
+      @create_new_page.click_create_new_acquisition
+      test_2_acquisition = { CoreAcquisitionData::ACQUIS_REF_NUM.name => Time.now.to_i }
+    #  test_2_ref_num = Time.now.to_i
+    #  @object_page.wait_for_element_and_type(@object_page.input_locator([],"acquisitionReferenceNumber"), test_1_ref_num)
+      @acquisition_page.create_new_acquisition test_2_acquisition
+      @acquisition_page.scroll_to_top
+      @acquisition_page.wait_for_element_and_click(related_proc_open_button)
+      header_text = @object_page.element_text(:xpath => '//div[contains(@class, "SearchResultSummary")]//span')
+      expect(header_text == "No records found")
+
+      @acquisition_page.wait_for_element_and_click(:xpath => "//a[contains(., \"#{test_2_acquisition[CoreAcquisitionData::ACQUIS_REF_NUM.name]}\")]")
+      @acquisition_page.select_related_type("Media Handling")
+      related_proc_1, related_proc_2 = Time.now.to_i, 6 * Time.now.to_i
+      [related_proc_1, related_proc_2].each do |ref_num|
+        @acquisition_page.click_create_new_button
+        @acquisition_page.wait_for_element_and_type(@acquisition_page.input_locator([],"identificationNumber"), ref_num)
+        @acquisition_page.save_record
+      end
+      @acquisition_page.wait_for_element_and_click(related_proc_open_button)
+      test_run.driver.navigate.refresh
+      [related_proc_1, related_proc_2].each do |ref_num|
+        related_proc_row = {:xpath => "//div[@role = \"gridcell\"][contains(text(), \"#{ref_num}\")]"}
+        expect(@acquisition_page.exists? related_proc_row)
+      end
+      title_bar_expected = {:xpath => "//header[contains(., \"Procedures related to \"#{test_2_acquisition[CoreAcquisitionData::ACQUIS_REF_NUM.name]}\"\")]"}
+      expect(@acquisition_page.exists? title_bar_expected)
+    end
+
+    it "test keyboard accessibility" do
+      ##TODO
+      #test that the search button (for Search Related Objects/Procedures) can be navigated to and activated by keyboard only
+      #expect: should be able to do all the above using keyboard only; tab-ordering and keys should be logical; should be able to see focus at all times  
+    end
+
+  end
+end


### PR DESCRIPTION
Updates: 
- "Right Side Bar - Search Related Records" test code in spec/right_side_bar_search.rb
- added methods for the right side bar "Open" button in core_sidebar.rb
- added comments to describe the unrelate button methods in collection_space_pages.rb

Right Side Bar - Search Related Records [[Test Plan](https://collectionspace.atlassian.net/wiki/spaces/COL/pages/359890945/Right+Side+Bar+-+Search+Related+Records+-+QA+Test+Plan)] [[JIRA](https://jira.ets.berkeley.edu/jira/browse/CC-1341)]