### PR TITLE
CC-1497 - BOTGARDEN UpdateRareFlagListener 

### DIFF
--- a/config/config_botgarden.rb
+++ b/config/config_botgarden.rb
@@ -1,0 +1,13 @@
+require_relative '../spec_helper'
+
+class ConfigBOTGARDEN < Config
+
+  def ConfigBOTGARDEN.base_url
+    Config.base_url Deployment::BOTGARDEN
+  end
+
+  def ConfigBOTGARDEN.admin
+    Config.admin_user Deployment::BOTGARDEN
+  end
+
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -39,7 +39,8 @@ bampfa:
     password: secret
 
 botgarden:
-  base_url: https://botgarden-qa.cspace.berkeley.edu
+  base_url: https://botgarden-dev.cspace.berkeley.edu/
+    #https://botgarden-qa.cspace.berkeley.edu
   admin:
     username: secret
     password: secret

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,7 +1,7 @@
 webdriver:
   browser: chrome
   headless: false
-  
+
 log_level: Logger::DEBUG
 
 timeout:

--- a/models/data/botgarden/botgarden_authorities/botgarden_concept_data.rb
+++ b/models/data/botgarden/botgarden_authorities/botgarden_concept_data.rb
@@ -1,0 +1,11 @@
+require_relative '../../../../spec_helper'
+
+class BOTGARDENConceptData < CoreUCBAuthorityData
+
+  DATA = [
+      CONCEPT_TERMS = new('conceptTermGroup'),
+      DISPLAY_NAME = new('termDisplayName'),
+      QUALIFIER = new('termQualifier')
+  ]
+
+end

--- a/models/data/botgarden/botgarden_authorities/botgarden_taxon_data.rb
+++ b/models/data/botgarden/botgarden_authorities/botgarden_taxon_data.rb
@@ -1,0 +1,17 @@
+require_relative '../../../../spec_helper'
+
+class BOTGARDENTaxonData < CoreUCBAuthorityData
+#CoreUCBAuthorityPage is used because CoreUCBTaxonPage/CoreTaxonPage does not exist
+
+  DATA = [
+      ACCESS_RESTRICTIONS = new('accessRestrictions'),
+      CONCEPT_TERMS = new('conceptTermGroup'),
+      CONSERV_ORG = new('conservationOrganization'),
+      CONSERV_CATEG = new('conservationCategory'),
+      DISPLAY_NAME = new('termDisplayName'),
+      TERM_GROUP = new('taxonTermGroup'),
+      PLANT_ATTRIB_GRP = new('plantAttributesGroup'),
+      QUALIFIER = new('termQualifier')
+  ]
+
+end

--- a/models/data/botgarden/botgarden_objects/botgarden_object_data.rb
+++ b/models/data/botgarden/botgarden_objects/botgarden_object_data.rb
@@ -12,7 +12,7 @@ class BOTGARDENObjectData < CoreUCBObjectData
       ASSOC_PPL_TYPE = new('assocPeopleType'),
       ASSOC_PPL_NOTE = new('assocPeopleNote'),
 
-
+      RARE = new('rare'),
       TAXON_IDENT_GRP = new('taxonomicIdentGroup'),
       TAXON_NAME = new('taxon'),
       TAXON_QUALIFIER = new('qualifier'),
@@ -22,7 +22,7 @@ class BOTGARDENObjectData < CoreUCBObjectData
       TAXON_REF = new('reference'),
       TAXON_PAGE = new('refPage'),
       TAXON_NOTE = new('notes'),
-      
+
       USAGE_GRP = new('usageGroup'),
       USAGE = new('usage'),
       USAGE_NOTE = new('usageNote')

--- a/models/data/botgarden/botgarden_objects/botgarden_object_data.rb
+++ b/models/data/botgarden/botgarden_objects/botgarden_object_data.rb
@@ -1,0 +1,30 @@
+class BOTGARDENObjectData < CoreUCBObjectData
+
+  DATA = [
+
+      ANNOT_GRP = new('annotationGroup'),
+      ANNOT_TYPE = new('annotationType'),
+      ANNOT_NOTE = new('annotationNote'),
+      ANNOT_DATE = new('annotationDate'),
+      ANNOT_AUTHOR = new('annotationAuthor'),
+      ASSOC_PPL_GRP = new('assocPeopleGroup'),
+      ASSOC_PPL = new('assocPeople'),
+      ASSOC_PPL_TYPE = new('assocPeopleType'),
+      ASSOC_PPL_NOTE = new('assocPeopleNote'),
+
+
+      TAXON_IDENT_GRP = new('taxonomicIdentGroup'),
+      TAXON_NAME = new('taxon'),
+      TAXON_QUALIFIER = new('qualifier'),
+      TAXON_BY = new('identBy'),
+      TAXON_INSTITUTION = new('institution'),
+      TAXON_KIND = new('identKind'),
+      TAXON_REF = new('reference'),
+      TAXON_PAGE = new('refPage'),
+      TAXON_NOTE = new('notes'),
+      
+      USAGE_GRP = new('usageGroup'),
+      USAGE = new('usage'),
+      USAGE_NOTE = new('usageNote')
+  ]
+end

--- a/models/data/core/core_authorities/core_concept_data.rb
+++ b/models/data/core/core_authorities/core_concept_data.rb
@@ -3,7 +3,9 @@ require_relative '../../../../spec_helper'
 class CoreConceptData < CoreAuthorityData
 
   DATA = [
-      CONCEPT_TERMS = new('conceptTermGroup')
+      CONCEPT_TERMS = new('conceptTermGroup'),
+      DISPLAY_NAME = new('termDisplayName'),
+      QUALIFIER = new('termQualifier')
   ]
 
 end

--- a/pages/botgarden/botgarden_authorities/botgarden_concept_page.rb
+++ b/pages/botgarden/botgarden_authorities/botgarden_concept_page.rb
@@ -1,0 +1,5 @@
+class BOTGARDENConceptPage < CoreUCBConceptPage
+
+  DEPLOYMENT = Deployment::BOTGARDEN
+
+end

--- a/pages/botgarden/botgarden_authorities/botgarden_taxon_page.rb
+++ b/pages/botgarden/botgarden_authorities/botgarden_taxon_page.rb
@@ -1,0 +1,31 @@
+class BOTGARDENTaxonPage < CoreUCBAuthorityPage
+#CoreUCBAuthorityPage is used because CoreUCBTaxonPage/CoreTaxonPage does not exist 
+
+  DEPLOYMENT = Deployment::BOTGARDEN
+
+  def attribute_conserv_categ_input(index); input_locator([fieldset(BOTGARDENTaxonData::PLANT_ATTRIB_GRP.name, index)], BOTGARDENTaxonData::CONSERV_CATEG.name) end
+  def attribute_conserv_categ_options(index); input_options_locator([fieldset(BOTGARDENTaxonData::PLANT_ATTRIB_GRP.name, index)], BOTGARDENTaxonData::CONSERV_CATEG.name) end
+
+  # PLANT ATTRIBUTE INFORMATION
+
+  def enter_attributes(data)
+    attributes = data[BOTGARDENTaxonData::PLANT_ATTRIB_GRP.name]
+    prep_fieldsets_for_test_data([fieldset(BOTGARDENTaxonData::PLANT_ATTRIB_GRP.name)], attributes)
+    attributes && attributes.each_with_index do |attribute, index|
+      logger.debug "Entering plant attribute information '#{attribute}' at index #{index}"
+      # TODO - attribute date input
+      # TODO - attribute height input
+      # TODO - attribute width input
+      # TODO - attribute DBH input
+      # TODO - attribute recorded by input
+      # TODO - attribute conservation organization input
+      enter_auto_complete(attribute_conserv_categ_input(index), attribute_conserv_categ_options(index), attribute[BOTGARDENTaxonData::CONSERV_CATEG.name])
+      # TODO - attribute habit input
+      # TODO - attribute climate rating input
+      # TODO - attribute frost sensitive input
+      # TODO - attribute medicinal use input
+      # TODO - attribute economic use input
+    end
+  end
+
+end

--- a/pages/botgarden/botgarden_create_new_page.rb
+++ b/pages/botgarden/botgarden_create_new_page.rb
@@ -1,0 +1,11 @@
+require_relative '../../spec_helper'
+
+class BOTGARDENCreateNewPage < CoreUCBCreateNewPage
+
+  include Logging
+  include Page
+  include CollectionSpacePages
+
+  DEPLOYMENT = Deployment::BOTGARDEN
+
+end

--- a/pages/botgarden/botgarden_login_page.rb
+++ b/pages/botgarden/botgarden_login_page.rb
@@ -1,6 +1,6 @@
 require_relative '../../spec_helper'
 
-class BOTGARDENLoginPage < CoreLoginPage
+class BOTGARDENLoginPage < CoreUCBLoginPage
 
   include Logging
   include Page

--- a/pages/botgarden/botgarden_login_page.rb
+++ b/pages/botgarden/botgarden_login_page.rb
@@ -1,0 +1,20 @@
+require_relative '../../spec_helper'
+
+class BOTGARDENLoginPage < CoreLoginPage
+
+  include Logging
+  include Page
+  include CollectionSpacePages
+
+  DEPLOYMENT = Deployment::BOTGARDEN
+
+  def page_heading; {:xpath => '//h2[contains(.,"UCBG CollectionSpace")]'} end
+
+  # Loads the BOTGARDEN homepage
+  def load_page
+    logger.info 'Loading BOTGARDEN homepage'
+    get ConfigBOTGARDEN.base_url
+    when_exists(page_heading, Config.medium_wait)
+  end
+
+end

--- a/pages/botgarden/botgarden_objects/botgarden_object_id_info_form.rb
+++ b/pages/botgarden/botgarden_objects/botgarden_object_id_info_form.rb
@@ -16,6 +16,8 @@ module BOTGARDENObjectIdInfoForm
 
   def object_num_input; input_locator([], BOTGARDENObjectData::OBJECT_NUM.name) end
 
+  def object_rarity; input_locator([], BOTGARDENObjectData::RARE.name) end
+
   def obj_type_input; input_locator([], BOTGARDENObjectData::COLLECTION.name) end
   def obj_type_options; input_options_locator([], BOTGARDENObjectData::COLLECTION.name) end
 
@@ -114,6 +116,16 @@ module BOTGARDENObjectIdInfoForm
       wait_for_element_and_type(taxon_ref_input(index), tax[BOTGARDENObjectData::TAXON_REF.name])
       wait_for_element_and_type(taxon_page_input(index), tax[BOTGARDENObjectData::TAXON_PAGE.name])
       wait_for_element_and_type(taxon_note_input(index), tax[BOTGARDENObjectData::TAXON_NOTE.name])
+    end
+  end
+
+  def enter_default_taxonomics(data)
+    taxonomics = data[BOTGARDENObjectData::TAXON_IDENT_GRP.name]
+    prep_fieldsets_for_test_data([fieldset(BOTGARDENObjectData::TAXON_IDENT_GRP.name)], taxonomics)
+    taxonomics && taxonomics.each_with_index do |tax, index|
+      logger.debug "Entering taxonomic information '#{tax}' at index #{index}"
+      enter_auto_complete(taxon_name_input(index), taxon_name_options(index), tax[BOTGARDENObjectData::TAXON_NAME.name], "Default Taxonomic Names")
+      #TODO - all other inputs
     end
   end
 

--- a/pages/botgarden/botgarden_objects/botgarden_object_id_info_form.rb
+++ b/pages/botgarden/botgarden_objects/botgarden_object_id_info_form.rb
@@ -1,0 +1,307 @@
+require_relative '../../../spec_helper'
+
+module BOTGARDENObjectIdInfoForm
+
+  include Logging
+  include Page
+  include CollectionSpacePages
+
+  DEPLOYMENT = Deployment::BOTGARDEN
+
+
+  def alt_num_input(index); input_locator([fieldset(BOTGARDENObjectData::ALT_NUM_GRP.name, index)], BOTGARDENObjectData::ALT_NUM.name) end
+  def alt_num_type_input(index); input_locator([fieldset(BOTGARDENObjectData::ALT_NUM_GRP.name, index)], BOTGARDENObjectData::ALT_NUM_TYPE.name) end
+  def alt_num_type_options(index); input_options_locator([fieldset(BOTGARDENObjectData::ALT_NUM_GRP.name, index)], BOTGARDENObjectData::ALT_NUM_TYPE.name) end
+  def alt_num_note_input(index); input_locator([fieldset(BOTGARDENObjectData::ALT_NUM_GRP.name, index)], BOTGARDENObjectData::ALT_NUM_NOTE.name) end
+
+  def object_num_input; input_locator([], BOTGARDENObjectData::OBJECT_NUM.name) end
+
+  def obj_type_input; input_locator([], BOTGARDENObjectData::COLLECTION.name) end
+  def obj_type_options; input_options_locator([], BOTGARDENObjectData::COLLECTION.name) end
+
+  def assoc_cult_grp_input(index);input_locator([fieldset(BOTGARDENObjectData::ASSOC_PPL_GRP.name, index)], BOTGARDENObjectData::ASSOC_PPL.name) end
+  def assoc_cult_grp_type_input(index); input_locator([fieldset(BOTGARDENObjectData::ASSOC_PPL_GRP.name, index)], BOTGARDENObjectData::ASSOC_PPL_TYPE.name) end
+  def assoc_cult_grp_type_options(index); input_options_locator([fieldset(BOTGARDENObjectData::ASSOC_PPL_GRP.name, index)], BOTGARDENObjectData::ASSOC_PPL_TYPE.name) end
+  def assoc_cult_grp_note_input(index); input_locator([fieldset(BOTGARDENObjectData::ASSOC_PPL_GRP.name, index)], BOTGARDENObjectData::ASSOC_PPL_NOTE.name) end
+
+
+  def annot_type_input(index); input_locator([fieldset(BOTGARDENObjectData::ANNOT_GRP.name, index)], BOTGARDENObjectData::ANNOT_TYPE.name) end
+  def annot_type_options(index); input_options_locator([fieldset(BOTGARDENObjectData::ANNOT_GRP.name, index)], BOTGARDENObjectData::ANNOT_TYPE.name) end
+  def annot_note_input(index); input_locator([fieldset(BOTGARDENObjectData::ANNOT_GRP.name, index)], BOTGARDENObjectData::ANNOT_NOTE.name) end
+  def annot_date_input(index); input_locator([fieldset(BOTGARDENObjectData::ANNOT_GRP.name, index)], BOTGARDENObjectData::ANNOT_DATE.name) end
+  def annot_author_input(index); input_locator([fieldset(BOTGARDENObjectData::ANNOT_GRP.name, index)], BOTGARDENObjectData::ANNOT_AUTHOR.name) end
+
+
+  def taxon_name_input(index); input_locator([fieldset(BOTGARDENObjectData::TAXON_IDENT_GRP.name, index)], BOTGARDENObjectData::TAXON_NAME.name) end
+  def taxon_name_options(index); input_options_locator([fieldset(BOTGARDENObjectData::TAXON_IDENT_GRP.name, index)], BOTGARDENObjectData::TAXON_NAME.name) end
+  def taxon_qualifier_input(index); input_locator([fieldset(BOTGARDENObjectData::TAXON_IDENT_GRP.name, index)], BOTGARDENObjectData::TAXON_QUALIFIER.name) end
+  def taxon_qualifier_options(index); input_options_locator([fieldset(BOTGARDENObjectData::TAXON_IDENT_GRP.name, index)], BOTGARDENObjectData::TAXON_QUALIFIER.name) end
+  def taxon_by_input(index); input_locator([fieldset(BOTGARDENObjectData::TAXON_IDENT_GRP.name, index)], BOTGARDENObjectData::TAXON_BY.name) end
+  def taxon_date_input(index); structured_date_input_locator([fieldset(BOTGARDENObjectData::TAXON_IDENT_GRP.name, index)]) end
+  def taxon_institution_input(index); input_locator([fieldset(BOTGARDENObjectData::TAXON_IDENT_GRP.name, index)], BOTGARDENObjectData::TAXON_INSTITUTION.name) end
+  def taxon_kind_input(index); input_locator([fieldset(BOTGARDENObjectData::TAXON_IDENT_GRP.name, index)], BOTGARDENObjectData::TAXON_KIND.name) end
+  def taxon_kind_options(index); input_options_locator([fieldset(BOTGARDENObjectData::TAXON_IDENT_GRP.name, index)], BOTGARDENObjectData::TAXON_KIND.name) end
+  def taxon_ref_input(index); input_locator([fieldset(BOTGARDENObjectData::TAXON_IDENT_GRP.name, index)], BOTGARDENObjectData::TAXON_REF.name) end
+  def taxon_page_input(index); input_locator([fieldset(BOTGARDENObjectData::TAXON_IDENT_GRP.name, index)], BOTGARDENObjectData::TAXON_PAGE.name) end
+  def taxon_note_input(index); text_area_locator([fieldset(BOTGARDENObjectData::TAXON_IDENT_GRP.name, index)], BOTGARDENObjectData::TAXON_NOTE.name) end
+
+
+  def usage_input(index); text_area_locator([fieldset(BOTGARDENObjectData::USAGE_GRP.name, index)], BOTGARDENObjectData::USAGE.name) end
+  def usage_note_input(index); text_area_locator([fieldset(BOTGARDENObjectData::USAGE_GRP.name, index)], BOTGARDENObjectData::USAGE_NOTE.name) end
+
+
+  # OBJECT NUM
+
+  def enter_object_number(data)
+    logger.debug "Entering object number '#{data[BOTGARDENObjectData::OBJECT_NUM.name]}'"
+    wait_for_element_and_type(object_num_input, data[BOTGARDENObjectData::OBJECT_NUM.name])
+  end
+
+  def verify_object_number(data)
+    tex
+  end
+
+
+
+  # ASSOCIATED CULTURAL GROUP
+
+  def enter_assoc_cult_grps(data)
+    assoc_cult_grps = data[BOTGARDENObjectData::ASSOC_PPL_GRP.name]
+    prep_fieldsets_for_test_data([fieldset(BOTGARDENObjectData::ASSOC_PPL_GRP.name)], assoc_cult_grps)
+    assoc_cult_grps && assoc_cult_grps.each_with_index do |assoc_cult, index|
+      logger.debug "Entering associated cultural group '#{assoc_cult}'"
+      # TODO - handle creation of input options
+      wait_for_element_and_type(assoc_cult_grp_input(index), assoc_cult[BOTGARDENObjectData::ASSOC_PPL.name])
+      wait_for_options_and_select(assoc_cult_grp_type_input(index), assoc_cult_grp_type_options(index), assoc_cult[BOTGARDENObjectData::ASSOC_PPL_TYPE.name])
+      wait_for_element_and_type(assoc_cult_grp_note_input(index), assoc_cult[BOTGARDENObjectData::ASSOC_PPL_NOTE.name])
+    end
+  end
+
+
+  # ANNOTATIONS
+
+  def enter_annotations(data)
+    annotations = data[BOTGARDENObjectData::ANNOT_GRP.name]
+    prep_fieldsets_for_test_data([fieldset(BOTGARDENObjectData::ANNOT_GRP.name)], annotations)
+    annotations && annotations.each_with_index do |annot, index|
+      logger.debug "Entering annotation '#{annot}' at index #{index}"
+      wait_for_options_and_select(annot_type_input(index), annot_type_options(index), annot[BOTGARDENObjectData::ANNOT_TYPE.name])
+      wait_for_element_and_type(annot_note_input(index), annot[BOTGARDENObjectData::ANNOT_NOTE.name])
+      enter_simple_date(annot_date_input(index), annot[BOTGARDENObjectData::ANNOT_DATE.name])
+      # TODO - handle creation of input options
+      wait_for_element_and_type(annot_author_input(index), annot[BOTGARDENObjectData::ANNOT_AUTHOR.name])
+    end
+  end
+
+
+  # TAXONOMIC INFORMATION
+
+  def enter_taxonomics(data)
+    taxonomics = data[BOTGARDENObjectData::TAXON_IDENT_GRP.name]
+    prep_fieldsets_for_test_data([fieldset(BOTGARDENObjectData::TAXON_IDENT_GRP.name)], taxonomics)
+    taxonomics && taxonomics.each_with_index do |tax, index|
+      logger.debug "Entering taxonomic information '#{tax}' at index #{index}"
+      # TODO - handle creation of input options
+      enter_auto_complete(taxon_name_input(index), taxon_name_options(index), tax[BOTGARDENObjectData::TAXON_NAME.name])
+      wait_for_options_and_select(taxon_qualifier_input(index), taxon_qualifier_options(index), tax[BOTGARDENObjectData::TAXON_QUALIFIER.name])
+      # TODO - handle creation of input options
+      wait_for_element_and_type(taxon_by_input(index), tax[BOTGARDENObjectData::TAXON_BY.name])
+      # TODO - taxon date input
+      # TODO - handle creation of input options
+      wait_for_element_and_type(taxon_institution_input(index), tax[BOTGARDENObjectData::TAXON_INSTITUTION.name])
+      wait_for_options_and_select(taxon_kind_input(index), taxon_kind_options(index), tax[BOTGARDENObjectData::TAXON_KIND.name])
+      # TODO - handle creation of input options
+      wait_for_element_and_type(taxon_ref_input(index), tax[BOTGARDENObjectData::TAXON_REF.name])
+      wait_for_element_and_type(taxon_page_input(index), tax[BOTGARDENObjectData::TAXON_PAGE.name])
+      wait_for_element_and_type(taxon_note_input(index), tax[BOTGARDENObjectData::TAXON_NOTE.name])
+    end
+  end
+
+
+  # USAGE
+
+  def enter_usages(data)
+    usages = data[BOTGARDENObjectData::USAGE_GRP.name]
+    prep_fieldsets_for_test_data([fieldset(BOTGARDENObjectData::USAGE_GRP.name)], usages)
+    usages && usages.each_with_index do |usage, index|
+      logger.debug "Entering usage '#{usage}' at index #{index}"
+      wait_for_element_and_type(usage_input(index), usage[BOTGARDENObjectData::USAGE.name])
+      wait_for_element_and_type(usage_note_input(index), usage[BOTGARDENObjectData::USAGE_NOTE.name])
+    end
+  end
+
+
+
+  def verify_object_info_data(data_set)
+    logger.debug "Checking object number #{data_set[BOTGARDENObjectData::OBJECT_NUM.name]}"
+    object_data_errors = []
+    text_values_match?(data_set[BOTGARDENObjectData::OBJECT_NUM.name], element_value(object_num_input), object_data_errors)
+
+    legacy_dept = data_set[BOTGARDENObjectData::LEGACY_DEPT.name]
+    legacy_dept && text_values_match?(legacy_dept, element_value(legacy_dept_input), object_data_errors)
+
+    num_pieces = data_set[BOTGARDENObjectData::NUM_OBJECTS.name]
+    num_pieces && text_values_match?(num_pieces, element_value(num_pieces_input), object_data_errors)
+
+    count_note = data_set[BOTGARDENObjectData::INVENTORY_COUNT.name]
+    count_note && text_values_match?(count_note, element_value(count_note_input), object_data_errors)
+
+    is_component = data_set[BOTGARDENObjectData::IS_COMPONENT.name]
+    is_component && text_values_match?(is_component, element_value(is_component_input), object_data_errors)
+
+    obj_statuses = data_set[BOTGARDENObjectData::OBJ_STATUS_LIST.name]
+    obj_statuses && obj_statuses.each do |obj_status|
+      index = obj_statuses.index obj_status
+      text_values_match?(obj_status[BOTGARDENObjectData::OBJ_STATUS.name], element_value(obj_status_input index), object_data_errors)
+    end
+
+    alt_nums = data_set[BOTGARDENObjectData::ALT_NUM_GRP.name]
+    alt_nums && alt_nums.each do |alt_num|
+      index = alt_nums.index alt_num
+      text_values_match?(alt_num[BOTGARDENObjectData::ALT_NUM.name], element_value(alt_num_input(index)), object_data_errors)
+      text_values_match?(alt_num[BOTGARDENObjectData::ALT_NUM_TYPE.name], element_value(alt_num_type_input(index)), object_data_errors)
+      text_values_match?(alt_num[BOTGARDENObjectData::ALT_NUM_NOTE.name], element_value(alt_num_note_input(index)), object_data_errors)
+    end
+
+    descrips = data_set[BOTGARDENObjectData::BRIEF_DESCRIPS.name]
+    descrips && descrips.each do |descrip|
+      index = descrips.index descrip
+      text_values_match?(descrip[BOTGARDENObjectData::BRIEF_DESCRIP.name], element_value(desc_text_area(index)), object_data_errors)
+    end
+
+    obj_classes = data_set[BOTGARDENObjectData::OBJ_CLASS_GRP.name]
+    obj_classes && obj_classes.each do |obj_class|
+      index = obj_classes.index obj_class
+      text_values_match?(obj_class[BOTGARDENObjectData::OBJ_CLASS_NAME.name], element_value(obj_class_name_input(index)), object_data_errors)
+    end
+
+    obj_names = data_set[BOTGARDENObjectData::OBJ_NAME_GRP.name]
+    obj_names && obj_names.each do |name|
+      index = obj_names.index name
+      text_values_match?(name[BOTGARDENObjectData::OBJ_NAME_NAME.name], element_value(object_name_input index), object_data_errors)
+      text_values_match?(name[BOTGARDENObjectData::OBJ_NAME_CURRENCY.name], element_value(object_name_currency_input index), object_data_errors)
+      text_values_match?(name[BOTGARDENObjectData::OBJ_NAME_LEVEL.name], element_value(object_name_level_input index), object_data_errors)
+      text_values_match?(name[BOTGARDENObjectData::OBJ_NAME_SYSTEM.name], element_value(object_name_system_input index), object_data_errors)
+      text_values_match?(name[BOTGARDENObjectData::OBJ_NAME_TYPE.name], element_value(object_name_type_input index), object_data_errors)
+      text_values_match?(name[BOTGARDENObjectData::OBJ_NAME_LANG.name], element_value(object_name_lang_input index), object_data_errors)
+      text_values_match?(name[BOTGARDENObjectData::OBJ_NAME_NOTE.name], element_value(object_name_note_input index), object_data_errors)
+    end
+
+    resp_colls = data_set[BOTGARDENObjectData::RESPONSIBLE_DEPTS.name]
+    resp_colls && resp_colls.each do |resp_coll|
+      index = resp_colls.index resp_coll
+      text_values_match?(resp_coll[BOTGARDENObjectData::RESPONSIBLE_DEPT.name], element_value(resp_coll_input index), object_data_errors)
+    end
+
+    obj_type = data_set[BOTGARDENObjectData::COLLECTION.name]
+    obj_type && text_values_match?(obj_type, element_value(obj_type_input), object_data_errors)
+
+    assoc_cult_grps = data_set[BOTGARDENObjectData::ASSOC_PPL_GRP.name]
+    assoc_cult_grps && assoc_cult_grps.each do |assoc_cult|
+      index = assoc_cult_grps.index assoc_cult
+      text_values_match?(assoc_cult[BOTGARDENObjectData::ASSOC_PPL.name], element_value(assoc_cult_grp_input index), object_data_errors)
+      text_values_match?(assoc_cult[BOTGARDENObjectData::ASSOC_PPL_TYPE.name], element_value(assoc_cult_grp_type_input index), object_data_errors)
+      text_values_match?(assoc_cult[BOTGARDENObjectData::ASSOC_PPL_NOTE.name], element_value(assoc_cult_grp_note_input index), object_data_errors)
+    end
+
+    ethno_file_codes = data_set[BOTGARDENObjectData::ETHNO_FILE_CODE_LIST.name]
+    ethno_file_codes && ethno_file_codes.each do |code|
+      index = ethno_file_codes.index code
+      text_values_match?(code[BOTGARDENObjectData::ETHNO_FILE_CODE.name], element_value(ethno_file_code_input index), object_data_errors)
+    end
+
+    obj_comments = data_set[BOTGARDENObjectData::COMMENTS.name]
+    obj_comments && obj_comments.each do |comment|
+      index = obj_comments.index comment
+      text_values_match?(comment[BOTGARDENObjectData::COMMENT.name], element_value(obj_comment_text_area index), object_data_errors)
+    end
+
+    annotations = data_set[BOTGARDENObjectData::ANNOT_GRP.name]
+    annotations && annotations.each do |annot|
+      index = annotations.index annot
+      text_values_match?(annot[BOTGARDENObjectData::ANNOT_TYPE.name], element_value(annot_type_input index), object_data_errors)
+      text_values_match?(annot[BOTGARDENObjectData::ANNOT_NOTE.name], element_value(annot_note_input index), object_data_errors)
+      text_values_match?(annot[BOTGARDENObjectData::ANNOT_DATE.name], element_value(annot_date_input index), object_data_errors)
+      text_values_match?(annot[BOTGARDENObjectData::ANNOT_AUTHOR.name], element_value(annot_author_input index), object_data_errors)
+    end
+
+    dimensions = data_set[BOTGARDENObjectData::MEASURE_PART_GRP.name]
+    dimensions && dimensions.each do |dim|
+      index = dimensions.index dim
+      text_values_match?(dim[BOTGARDENObjectData::MEASURE_PART.name], element_value(part_measured_input index), object_data_errors)
+      measures = dim[BOTGARDENObjectData::MEASURE_DIMEN_GRP.name]
+      measures && measures.each do |meas|
+        sub_index = measures.index meas
+        indices = [index, sub_index]
+        text_values_match?(meas[BOTGARDENObjectData::MEASURE_DIMENSION.name], element_value(measure_dimen_input indices), object_data_errors)
+        text_values_match?(meas[BOTGARDENObjectData::MEASURE_BY.name], element_value(measure_by_input indices), object_data_errors)
+        text_values_match?(meas[BOTGARDENObjectData::MEASURE_VALUE.name], element_value(measure_value_input indices), object_data_errors)
+        text_values_match?(meas[BOTGARDENObjectData::MEASURE_UNIT.name], element_value(measure_unit_input indices), object_data_errors)
+        text_values_match?(meas[BOTGARDENObjectData::MEASURE_QUALIFIER.name], element_value(measure_qualifier_input indices), object_data_errors)
+        text_values_match?(meas[BOTGARDENObjectData::MEASURE_DATE.name], element_value(measure_date_input indices), object_data_errors)
+        text_values_match?(meas[BOTGARDENObjectData::MEASURE_NOTE.name], element_value(measure_note_input indices), object_data_errors)
+      end
+    end
+
+    materials = data_set[BOTGARDENObjectData::MATERIAL_GRP.name]
+    materials && materials.each do |mat|
+      index = materials.index mat
+      text_values_match?(mat[BOTGARDENObjectData::MATERIAL.name], element_value(material_input index), object_data_errors)
+      text_values_match?(mat[BOTGARDENObjectData::MATERIAL_COMPONENT.name], element_value(material_component_input index), object_data_errors)
+      text_values_match?(mat[BOTGARDENObjectData::MATERIAL_NAME.name], element_value(material_name_input index), object_data_errors)
+      text_values_match?(mat[BOTGARDENObjectData::MATERIAL_SOURCE.name], element_value(material_source_input index), object_data_errors)
+      text_values_match?(mat[BOTGARDENObjectData::MATERIAL_NOTE.name], element_value(material_note_input index), object_data_errors)
+    end
+
+    taxonomics = data_set[BOTGARDENObjectData::TAXON_IDENT_GRP.name]
+    taxonomics && taxonomics.each do |tax|
+      index = taxonomics.index tax
+      text_values_match?(tax[BOTGARDENObjectData::TAXON_NAME.name], element_value(taxon_name_input index), object_data_errors)
+      text_values_match?(tax[BOTGARDENObjectData::TAXON_QUALIFIER.name], element_value(taxon_qualifier_input index), object_data_errors)
+      text_values_match?(tax[BOTGARDENObjectData::TAXON_BY.name], element_value(taxon_by_input index), object_data_errors)
+      text_values_match?(tax[BOTGARDENObjectData::TAXON_INSTITUTION.name], element_value(taxon_institution_input index), object_data_errors)
+      text_values_match?(tax[BOTGARDENObjectData::TAXON_KIND.name], element_value(taxon_kind_input index), object_data_errors)
+      text_values_match?(tax[BOTGARDENObjectData::TAXON_REF.name], element_value(taxon_ref_input index), object_data_errors)
+      text_values_match?(tax[BOTGARDENObjectData::TAXON_PAGE.name], element_value(taxon_page_input index), object_data_errors)
+      text_values_match?(tax[BOTGARDENObjectData::TAXON_NOTE.name], element_value(taxon_note_input index), object_data_errors)
+    end
+
+    titles = data_set[BOTGARDENObjectData::TITLE_GRP.name]
+    titles && titles.each do |title|
+      index = titles.index title
+      text_values_match?(title[BOTGARDENObjectData::TITLE.name], element_value(title_input index), object_data_errors)
+      text_values_match?(title[BOTGARDENObjectData::TITLE_TYPE.name], element_value(title_type_input index), object_data_errors)
+      text_values_match?(title[BOTGARDENObjectData::TITLE_LANG.name], element_value(title_lang_input index), object_data_errors)
+
+      translations = title[BOTGARDENObjectData::TITLE_TRANSLATION_SUB_GRP.name]
+      translations && translations.each do |trans|
+        sub_index = translations.index trans
+        text_values_match?(trans[BOTGARDENObjectData::TITLE_TRANSLATION.name], element_value(title_translation_input [index, sub_index]), object_data_errors)
+        text_values_match?(trans[BOTGARDENObjectData::TITLE_TRANSLATION_LANG.name], element_value(title_translation_lang_input [index, sub_index]), object_data_errors)
+      end
+    end
+
+    usages = data_set[BOTGARDENObjectData::USAGE_GRP.name]
+    usages && usages.each do |usage|
+      index = usages.index usage
+      text_values_match?(usage[BOTGARDENObjectData::USAGE.name], element_value(usage_input index), object_data_errors)
+      text_values_match?(usage[BOTGARDENObjectData::USAGE_NOTE.name], element_value(usage_note_input index), object_data_errors)
+    end
+
+    series = data_set[BOTGARDENObjectData::AUDIO_SERIES.name]
+    series && text_values_match?(series, element_value(series_input), object_data_errors)
+
+    collections = data_set[BOTGARDENObjectData::PAHMA_COLLECTION_LIST.name]
+    collections && collections.each do |collect|
+      index = collections.index collect
+      text_values_match?(collect[BOTGARDENObjectData::PAHMA_COLLECTION.name], element_value(collection_input index), object_data_errors)
+    end
+
+    tms_source = data_set[BOTGARDENObjectData::TMS_DATA_SRC.name]
+    tms_source && text_values_match?(tms_source, element_value(tms_data_source_input), object_data_errors)
+
+    logger.warn "Object data errors: #{object_data_errors}"
+    object_data_errors
+  end
+
+end

--- a/pages/botgarden/botgarden_objects/botgarden_object_page.rb
+++ b/pages/botgarden/botgarden_objects/botgarden_object_page.rb
@@ -1,0 +1,41 @@
+require_relative '../../../spec_helper'
+
+class BOTGARDENObjectPage < CoreUCBObjectPage
+
+  include Logging
+  include Page
+  include CollectionSpacePages
+#  include BOTGARDENPages
+  include BOTGARDENSidebar
+  include BOTGARDENObjectIdInfoForm
+
+  DEPLOYMENT = Deployment::BOTGARDEN
+
+  def enter_object_id_data(data)
+    enter_object_number data
+    select_legacy_dept data
+    enter_num_pieces data
+    enter_count_note data
+    select_is_component data
+    select_object_statuses data
+    enter_alt_num data
+    enter_description data
+    enter_object_classes data
+    enter_object_names data
+    select_resp_colls data
+    enter_object_type data
+    enter_assoc_cult_grps data
+    enter_enthno_file_codes data
+    enter_object_comments data
+    enter_annotations data
+    enter_dimensions data
+    enter_materials data
+    enter_taxonomics data
+    enter_titles data
+    enter_usages data
+    select_series data
+    select_collections data
+    select_tms_source data
+  end
+
+end

--- a/pages/botgarden/botgarden_search/botgarden_search_page.rb
+++ b/pages/botgarden/botgarden_search/botgarden_search_page.rb
@@ -1,0 +1,24 @@
+require_relative '../../../spec_helper'
+
+class BOTGARDENSearchPage < CoreUCBSearchPage
+
+  include Page
+  include CollectionSpacePages
+
+  DEPLOYMENT = Deployment::BOTGARDEN
+
+  # OBJECT NUMBER
+=begin
+  def object_num_input(index)
+    input_locator [fieldset(BOTGARDENObjectPage::OBJECT_NUM.name, index)]
+  end
+
+  def object_num_delete_btn(index)
+    delete_button_locator [fieldset(BOTGARDENObjectPage::OBJECT_NUM.name, index)]
+  end
+
+  def object_num_add_btn
+    add_button_locator [fieldset(BOTGARDENObjectPage::OBJECT_NUM.name)]
+  end
+=end
+end

--- a/pages/botgarden/botgarden_search/botgarden_search_results_page.rb
+++ b/pages/botgarden/botgarden_search/botgarden_search_results_page.rb
@@ -1,0 +1,11 @@
+require_relative '../../../spec_helper'
+
+class BOTGARDENSearchResultsPage < CoreUCBSearchResultsPage
+
+  include Logging
+  include Page
+  include CollectionSpacePages
+
+  DEPLOYMENT = Deployment::BOTGARDEN
+
+end

--- a/pages/botgarden/botgarden_search/botgarden_search_results_page.rb
+++ b/pages/botgarden/botgarden_search/botgarden_search_results_page.rb
@@ -8,4 +8,10 @@ class BOTGARDENSearchResultsPage < CoreUCBSearchResultsPage
 
   DEPLOYMENT = Deployment::BOTGARDEN
 
+  # Returns the display name for a search result row
+  # @param [Integer] row number
+  def name_of_nth_row(value)
+    element_text(:xpath => "//div[@class=\"cspace-ui-SearchResultTable--common\"]//*[@aria-label=\"row\"][#{value}]//div[@aria-colindex = 3]")
+  end
+
 end

--- a/pages/botgarden/botgarden_sidebar.rb
+++ b/pages/botgarden/botgarden_sidebar.rb
@@ -1,0 +1,8 @@
+require_relative '../../spec_helper'
+
+module BOTGARDENSidebar
+
+  include CoreUCBSidebar
+
+
+end

--- a/pages/core/core_authorities/core_concept_page.rb
+++ b/pages/core/core_authorities/core_concept_page.rb
@@ -5,11 +5,12 @@ class CoreConceptPage < CoreAuthorityPage
   include Logging
   include Page
   include CollectionSpacePages
-  
+
   DEPLOYMENT = Deployment::CORE
 
   def display_name_input(index); input_locator([fieldset(CoreConceptData::CONCEPT_TERMS.name, index)], CoreConceptData::TERM_DISPLAY_NAME.name) end
   def display_name_add_btn; add_button_locator([fieldset(CoreConceptData::CONCEPT_TERMS.name)]) end
+  def qualifier_name_input(index); input_locator([fieldset(CoreConceptData::CONCEPT_TERMS.name, index)], CoreConceptData::QUALIFIER.name) end
 
   def enter_display_name(name, index)
     logger.debug "Entering display name '#{name}'"
@@ -29,5 +30,11 @@ class CoreConceptPage < CoreAuthorityPage
 
   def enter_number(data)
     enter_acquisition_ref_num data
+  end
+
+  def verify_qualifier_name(name, index)
+    wait_until(Config.short_wait, "Expected qualifier name '#{name}', but got '#{element_value(qualifier_name_input index)}'") do
+      text_values_match?(name, element_value(qualifier_name_input index))
+    end
   end
 end

--- a/pages/core/core_search/core_search_results_page.rb
+++ b/pages/core/core_search/core_search_results_page.rb
@@ -74,7 +74,7 @@ class CoreSearchResultsPage
   # Returns the display name for a search result row
   # @param [Integer] row number
   def name_of_nth_row(value)
-    element_text(:xpath => "//div[@class=\"cspace-ui-SearchResultTable--common\"]//*[@aria-label=\"row\"][#{value}]")
+    element_text(:xpath => "//div[@class=\"cspace-ui-SearchResultTable--common\"]//*[@aria-label=\"row\"][#{value}]//div[@aria-colindex = 2]")
   end
 
   def click_search_result_cbx(identifier)

--- a/pages/core/core_search/core_search_results_page.rb
+++ b/pages/core/core_search/core_search_results_page.rb
@@ -70,7 +70,13 @@ class CoreSearchResultsPage
   def select_result_nth_row(value)
     wait_for_element_and_click(:xpath => "//div[@class=\"cspace-ui-SearchResultTable--common\"]//*[@aria-label=\"row\"][#{value}]")
   end
-  
+
+  # Returns the display name for a search result row
+  # @param [Integer] row number
+  def name_of_nth_row(value)
+    element_text(:xpath => "//div[@class=\"cspace-ui-SearchResultTable--common\"]//*[@aria-label=\"row\"][#{value}]")
+  end
+
   def click_search_result_cbx(identifier)
     wait_for_element_and_click search_result_checkbox(identifier)
   end

--- a/spec/event_listeners/botgarden/UpdateRareFlagListener.rb
+++ b/spec/event_listeners/botgarden/UpdateRareFlagListener.rb
@@ -9,45 +9,79 @@ describe 'BOTGARDEN' do
   before(:all) do
     @test = TestConfig.new deploy
     @test.set_driver launch_browser
-  #  @admin = @test.get_admin_user
-    @login_page = @test.get_page CoreLoginPage
-    @search_page = @test.get_page CoreSearchPage
-    @search_results_page = @test.get_page CoreSearchResultsPage
-    @login_page.load_page
+
+    @admin = @test.get_admin_user
     @concept_page = @test.get_page CoreConceptPage
     @create_new_page = @test.get_page CoreCreateNewPage
+    @login_page = @test.get_page CoreLoginPage
     @object_page = @test.get_page CoreObjectPage
-    @login_page.log_in("sehyunhwang@berkeley.edu", "cspacestudents")
-    #@admin.username, @admin.password)
+    @search_page = @test.get_page CoreSearchPage
+    @search_results_page = @test.get_page CoreSearchResultsPage
+    @taxon_page = @test.get_page CoreUCBAuthorityPage
+
+    @login_page.load_page
+    @login_page.log_in(@admin.username, @admin.password)
   end
 
   after(:all) { quit_browser @test.driver }
 
-  search_result = "N/A"
+  #Variables for tests
+  scientific_name = "test"+Time.now.to_i.to_s
+  obj_rec = {
+    BOTGARDENObjectData::OBJECT_NUM.name => Time.now.to_i,
+    BOTGARDENObjectData::TAXON_IDENT_GRP.name => [{BOTGARDENObjectData::TAXON_NAME.name => scientific_name}]
+  }
+  red_dot_record = "N/A"
+  title_bar = {:xpath => '//header[contains(@class,"TitleBar")]//h1'}
 
   it "find conservation category value with set qualifier field" do
     @search_page.quick_search("Concepts", "Conservation Category", "red dot on label")
-    search_result = @search_results_page.name_of_nth_row(1)
+    red_dot_record = @search_results_page.name_of_nth_row(1)
     @search_results_page.select_result_nth_row(1)
-  #  @concept_page.refresh_page
     @concept_page.verify_qualifier_name("red dot on label", 0)
   end
 
-  it "create a new object record" do
+  it "create a new object record for #{scientific_name} taxon" do
     @concept_page.click_create_new_link
     @create_new_page.click_create_new_object
-    obj_rec = {
-      BOTGARDENObjectData::OBJECT_NUM.name => "1345433",
-      BOTGARDENObjectData::TAXON_IDENT_GRP.name => [{BOTGARDENObjectData::TAXON_NAME.name => "Astelia"}]
-    }
     @object_page.enter_object_number obj_rec
-    @object_page.enter_taxonomics obj_rec
+    @object_page.enter_default_taxonomics obj_rec
 
-    @object_page.save_record
-    ##EXPECTED
-    #record should save
-    #
+    summary = "#{obj_rec[BOTGARDENObjectData::OBJECT_NUM.name]} – #{scientific_name}"
+    @object_page.click_save_button
+    @object_page.wait_for_notification("Saving #{summary}")
+    @object_page.wait_for_notification("Saved #{summary}")
+    @object_page.verify_values_match(summary, @object_page.element_text(title_bar))
 
+    #value in Rare field should be "no"; if yes, enter a unique Taxon name for scientific_name
+    #and re-run test (confirm that Rare = "no")
+    expect(@object_page.element_value(@object_page.object_rarity) == "no").to be true
+  end
+
+  it "set Conservation category field to term with Qualifier" do
+    @object_page.expand_sidebar_terms_used
+    @object_page.click_sidebar_term(scientific_name)
+
+    taxon = {BOTGARDENTaxonData::PLANT_ATTRIB_GRP.name => [{BOTGARDENTaxonData::CONSERV_CATEG.name => red_dot_record}]}
+    @taxon_page.enter_attributes(taxon)
+    @taxon_page.click_save_button
+
+    summary = "#{scientific_name}" # no TERM_STATUS value created for new test taxon
+    @object_page.verify_values_match(scientific_name, @taxon_page.element_text(title_bar))
+    @taxon_page.wait_for_notification("Saving #{summary}")
+    @taxon_page.wait_for_notification("Saved #{summary}")
+    expect(@taxon_page.exists? @taxon_page.terms_used_term_link(red_dot_record))
+  end
+
+  it "confirm that the Rare field has been set to 'yes'" do
+    @taxon_page.hide_notifications_bar
+    @taxon_page.scroll_to_top
+    @taxon_page.expand_sidebar_used_by
+    @taxon_page.click_sidebar_used_by(obj_rec[BOTGARDENObjectData::OBJECT_NUM.name])
+
+    @object_page.when_exists(@object_page.object_rarity, Config.short_wait)
+    @object_page.scroll_to_element(@object_page.object_rarity)
+    expect(@object_page.element_value(@object_page.object_rarity) == "yes").to be true
   end
 
 end

--- a/spec/event_listeners/botgarden/UpdateRareFlagListener.rb
+++ b/spec/event_listeners/botgarden/UpdateRareFlagListener.rb
@@ -1,0 +1,41 @@
+require_relative '../../../spec_helper'
+test_run = TestConfig.new Deployment::BOTGARDEN
+
+describe 'BOTGARDEN' do
+
+  include Logging
+  include WebDriverManager
+
+  before(:all) do
+
+    test_run.set_driver launch_browser
+    @admin = test_run.get_admin_user
+    @login_page = test_run.get_page BOTGARDENLoginPage
+  #  @search_page = test_run.get_page CoreSearchPage
+  #  @search_results_page = test_run.get_page CoreSearchResultsPage
+    @login_page.load_page
+  #  @concept_page = test_run.get_page CoreConceptPage
+  #  @create_new_page = test_run.get_page CoreCreateNewPage
+    @login_page.log_in("sehyunhwang@berkeley.edu", "cspacestudents")
+    #@admin.username, @admin.password)
+  end
+
+  after(:all) { quit_browser test_run.driver }
+=begin
+  search_result = "N/A"
+
+  it "find conservation category value with set qualifier field" do
+    @search_page.quick_search("Concepts", "Conservation Category", "red dot on label")
+    search_result = @search_result.name_of_nth_row(1)
+    @search_result.select_result_nth_row(1)
+
+    qualifier_text = @concept_page.element_value(@concept_page.input_locator([], "termQualifier"))
+    @concept_page.verify_values_match("red dot on label", qualifier_text)
+  end
+
+  it "create a new object record" do
+    @concept_page.click_create_new_link
+    @create_new_page.click_create_new_object
+  end
+=end
+end

--- a/spec/event_listeners/botgarden/UpdateRareFlagListener.rb
+++ b/spec/event_listeners/botgarden/UpdateRareFlagListener.rb
@@ -1,5 +1,5 @@
 require_relative '../../../spec_helper'
-test_run = TestConfig.new Deployment::BOTGARDEN
+deploy = Deployment::BOTGARDEN
 
 describe 'BOTGARDEN' do
 
@@ -7,10 +7,10 @@ describe 'BOTGARDEN' do
   include WebDriverManager
 
   before(:all) do
-
-    test_run.set_driver launch_browser
-    @admin = test_run.get_admin_user
-    @login_page = test_run.get_page BOTGARDENLoginPage
+    @test = TestConfig.new deploy
+    @test.set_driver launch_browser
+    @admin = @test.get_admin_user
+    @login_page = @test.get_page BOTGARDENLoginPage
   #  @search_page = test_run.get_page CoreSearchPage
   #  @search_results_page = test_run.get_page CoreSearchResultsPage
     @login_page.load_page
@@ -20,8 +20,8 @@ describe 'BOTGARDEN' do
     #@admin.username, @admin.password)
   end
 
-  after(:all) { quit_browser test_run.driver }
-=begin
+  after(:all) { quit_browser @test.driver }
+
   search_result = "N/A"
 
   it "find conservation category value with set qualifier field" do
@@ -37,5 +37,5 @@ describe 'BOTGARDEN' do
     @concept_page.click_create_new_link
     @create_new_page.click_create_new_object
   end
-=end
+
 end

--- a/spec/event_listeners/botgarden/UpdateRareFlagListener.rb
+++ b/spec/event_listeners/botgarden/UpdateRareFlagListener.rb
@@ -9,13 +9,14 @@ describe 'BOTGARDEN' do
   before(:all) do
     @test = TestConfig.new deploy
     @test.set_driver launch_browser
-    @admin = @test.get_admin_user
-    @login_page = @test.get_page BOTGARDENLoginPage
-  #  @search_page = test_run.get_page CoreSearchPage
-  #  @search_results_page = test_run.get_page CoreSearchResultsPage
+  #  @admin = @test.get_admin_user
+    @login_page = @test.get_page CoreLoginPage
+    @search_page = @test.get_page CoreSearchPage
+    @search_results_page = @test.get_page CoreSearchResultsPage
     @login_page.load_page
-  #  @concept_page = test_run.get_page CoreConceptPage
-  #  @create_new_page = test_run.get_page CoreCreateNewPage
+    @concept_page = @test.get_page CoreConceptPage
+    @create_new_page = @test.get_page CoreCreateNewPage
+    @object_page = @test.get_page CoreObjectPage
     @login_page.log_in("sehyunhwang@berkeley.edu", "cspacestudents")
     #@admin.username, @admin.password)
   end
@@ -26,16 +27,27 @@ describe 'BOTGARDEN' do
 
   it "find conservation category value with set qualifier field" do
     @search_page.quick_search("Concepts", "Conservation Category", "red dot on label")
-    search_result = @search_result.name_of_nth_row(1)
-    @search_result.select_result_nth_row(1)
-
-    qualifier_text = @concept_page.element_value(@concept_page.input_locator([], "termQualifier"))
-    @concept_page.verify_values_match("red dot on label", qualifier_text)
+    search_result = @search_results_page.name_of_nth_row(1)
+    @search_results_page.select_result_nth_row(1)
+  #  @concept_page.refresh_page
+    @concept_page.verify_qualifier_name("red dot on label", 0)
   end
 
   it "create a new object record" do
     @concept_page.click_create_new_link
     @create_new_page.click_create_new_object
+    obj_rec = {
+      BOTGARDENObjectData::OBJECT_NUM.name => "1345433",
+      BOTGARDENObjectData::TAXON_IDENT_GRP.name => [{BOTGARDENObjectData::TAXON_NAME.name => "Astelia"}]
+    }
+    @object_page.enter_object_number obj_rec
+    @object_page.enter_taxonomics obj_rec
+
+    @object_page.save_record
+    ##EXPECTED
+    #record should save
+    #
+
   end
 
 end

--- a/spec_helper.rb
+++ b/spec_helper.rb
@@ -102,7 +102,7 @@ require_relative 'pages/core/core_admin/core_admin_page'
 
 Dir.glob("config/config_*").each { |file| require_relative file if file.include? '.rb' }
 
-%w(bampfa botgarden cinefiles core_ucb pahma ucjeps).each do |deployment|
+%w(core_ucb bampfa botgarden cinefiles pahma ucjeps).each do |deployment|
   Dir.glob("models/data/#{deployment}/*").each { |file| require_relative file if file.include? '.rb' }
   Dir.glob("models/data/#{deployment}/#{deployment}_authorities/*").each { |file| require_relative file if file.include? '.rb' }
   Dir.glob("models/data/#{deployment}/#{deployment}_objects/*").each { |file| require_relative file if file.include? '.rb' }


### PR DESCRIPTION
CC-1497: BOTGARDEN Event Listener -- UpdateRareFlagListener
- Set-up new page files to enable BOTGARDEN tests
- Created UpdateRareFlagListener test
> This test creates a new taxon record with no listed TERM_STATUS; expected phrases for tests (line 69) are written specifically to reflect no TERM_STATUS value

[[Test Plan](https://docs.google.com/document/d/1Ao16uKhFW3V7p4o1JuCPYlx-WV96vE61m-C2R9uK_uE/edit?usp=sharing)][[JIRA](https://jira.ets.berkeley.edu/jira/browse/CC-1497)]